### PR TITLE
Fix path object bug when copying PPTX

### DIFF
--- a/presentation_gui.py
+++ b/presentation_gui.py
@@ -349,7 +349,7 @@ def generar_cb(s=None, a=None, u=None):
     # Copiar PPTX al directorio de sincronización
     src, dst = ROOT_DIR / "outputs", SYNC_ROOT / mes / "outputs"
     dst.mkdir(exist_ok=True)
-    pptxs = [shutil.copy2(p, dst / p.name) for p in src.glob("*.pptx")]
+    pptxs = [Path(shutil.copy2(p, dst / p.name)) for p in src.glob("*.pptx")]
     if not pptxs:
         set_status("⚠ No se encontró ningún .pptx para copiar", err=True)
         dpg.configure_item(TAG_SPINNER, show=False)


### PR DESCRIPTION
## Summary
- fix type returned when copying PPTX files so `stat()` works

## Testing
- `python3 -m py_compile presentation_gui.py graphs.py generate_presentation.py ind_graphs/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68559a537aec8321a30a8fadd298d6ed