### PR TITLE
Refactor paths to use configurable data root

### DIFF
--- a/generate_presentation.py
+++ b/generate_presentation.py
@@ -19,11 +19,14 @@ from pptx.slide import Slide
 from pptx.util import Emu, Inches
 
 import graphs
+from utils import make_dirs_if_missing
+
+assert graphs.PATHS_SET, "graphs.set_paths() must be called first"
 
 # ───── rutas
 TEMPLATE_PATH = r".\inputs\Template.pptx"
 OUT_DIR = r".\outputs"
-os.makedirs(OUT_DIR, exist_ok=True)
+make_dirs_if_missing(OUT_DIR)
 
 
 # ───── capturar figuras

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parent
+CONFIG_PATH = ROOT / "chapter_config.json"
+
+try:
+    _cfg = json.loads(CONFIG_PATH.read_text("utf-8"))
+except Exception:
+    _cfg = {}
+
+DATA_ROOT = Path(_cfg.get("data_dir") or ROOT)
+
+
+def get_months(root: str | Path | None = None) -> list[str]:
+    pat = re.compile(r"^20\d{2} [01]\d$")
+    base = Path(root) if root else DATA_ROOT
+    if not base.is_dir():
+        return []
+    return sorted(p.name for p in base.iterdir() if p.is_dir() and pat.match(p.name))
+
+

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def make_dirs_if_missing(*dirs: str | Path) -> None:
+    for d in dirs:
+        Path(d).mkdir(parents=True, exist_ok=True)
+


### PR DESCRIPTION
## Summary
- centralize configuration in new `settings` module
- add helper `make_dirs_if_missing`
- refactor `graphs` for configurable paths
- require `graphs.set_paths` when generating presentations
- update GUI to manage data paths and demo mode

## Testing
- `python -m py_compile settings.py utils.py graphs.py generate_presentation.py presentation_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6855af4451d08321af55d7c71af040a7