### PR TITLE
Improve GUI error reporting

### DIFF
--- a/chapter_sync/gui.py
+++ b/chapter_sync/gui.py
@@ -19,6 +19,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import List, Tuple
+import traceback
 
 import dearpygui.dearpygui as dpg
 
@@ -335,7 +336,16 @@ def _gen_ppt(cl: str, email: str, data_dir: str):
         ultimo = max(pptxs, key=lambda p: p.stat().st_mtime)
         return True, "Presentación generada.", str(src_dir), str(ultimo)
     except Exception as exc:
-        return False, f"Error: {exc}", None, None
+        tb = traceback.extract_tb(exc.__traceback__)
+        if tb:
+            last = tb[-1]
+            mod = Path(last.filename).stem
+            fn = last.name
+            err = f"Error en {mod}.{fn}: {exc}"
+        else:
+            err = f"Error: {exc}"
+        log_message(traceback.format_exc(), "error")
+        return False, err, None, None
 
 
 # ─── util cross-thread → hilo GUI ────────────────────────────────────


### PR DESCRIPTION
## Summary
- surface detailed error info when generating PPTs via GUI
- log traceback details so users can identify failing module/function

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(no tests found)*
- `pip install -e .` *(failed: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686550cdbfc48321a942f1abc3a1b12e